### PR TITLE
[WDP210101-16] Add Media Queries for features section

### DIFF
--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -1,9 +1,13 @@
 @import "../../../styles/settings.scss";
-
+@import "./../../../styles/mixins.scss";
 .root {
   border: 1px solid $featureBox-border;
   text-align: center;
   margin-top: 40px;
+
+  @include mobile {
+    height: 9rem;
+  }
 
   .iconWrapper {
     height: 60px;
@@ -51,6 +55,16 @@
     margin-top: -0.5rem;
     letter-spacing: 1px;
     font-weight: 300;
+
+    @include mobile {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-around;
+      height: 60%;
+      & * {
+        font-size: 1rem;
+      }
+    }
 
     h5 {
       font-weight: 600;

--- a/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
@@ -1,5 +1,33 @@
 @import "../../../styles/settings.scss";
+@import "./../../../styles/mixins.scss";
 
 .root {
   padding: 5rem 0;
+  width: 100vw;
+
+  :global(.container) {
+    width: 100%;
+  }
+
+  :global(.row) {
+    @include tablet {
+      width: 100%;
+      margin: 0;
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    @include mobile {
+      width: 100%;
+      margin: 0;
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    :global(.col):nth-child(n + 3) {
+      @include mobile {
+        margin-top: 2rem;
+      }
+    }
+  }
 }


### PR DESCRIPTION
What to do:

- Features boxes on mobile and tablet should be displayed in 2 rows, 2 items per row
- Each box should have same height 

What I've done:

- Add inline queries with grid
- Add inline queries for each box to adjust height
- Reduce text size on small devices (this was not part of task, but I think it looks better this way)