### PR TITLE
[WDP210101-37] Modify menu links

### DIFF
--- a/src/components/layout/MenuBar/MenuBar.js
+++ b/src/components/layout/MenuBar/MenuBar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { NavLink } from 'react-router-dom';
 
 import ProductSearch from '../../features/ProductSearch/ProductSearch';
 
@@ -17,31 +18,29 @@ const MenuBar = ({ children }) => (
           <label htmlFor='nav' className={styles.menuButton}>
             <span className={styles.menuIcon}></span>
           </label>
-          <ul>
-            <li>
-              <a href='#' className={styles.active}>
-                Home
-              </a>
-            </li>
-            <li>
-              <a href='#'>Furniture</a>
-            </li>
-            <li>
-              <a href='#'>Chair</a>
-            </li>
-            <li>
-              <a href='#'>Table</a>
-            </li>
-            <li>
-              <a href='#'>Sofa</a>
-            </li>
-            <li>
-              <a href='#'>Bedroom</a>
-            </li>
-            <li>
-              <a href='#'>Blog</a>
-            </li>
-          </ul>
+          <nav className={styles.menu}>
+            <NavLink exact to='/' activeClassName={styles.active}>
+              Home
+            </NavLink>
+            <NavLink exact to='/shop/furniture' activeClassName={styles.active}>
+              Furniture
+            </NavLink>
+            <NavLink exact to='/shop/chair' activeClassName={styles.active}>
+              Chair
+            </NavLink>
+            <NavLink exact to='/shop/table' activeClassName={styles.active}>
+              Table
+            </NavLink>
+            <NavLink exact to='/shop/sofa' activeClassName={styles.active}>
+              Sofa
+            </NavLink>
+            <NavLink exact to='/shop/bedroom' activeClassName={styles.active}>
+              Bedroom
+            </NavLink>
+            <NavLink exact to='/blog' activeClassName={styles.active}>
+              Blog
+            </NavLink>
+          </nav>
         </div>
       </div>
     </div>

--- a/src/components/layout/MenuBar/MenuBar.module.scss
+++ b/src/components/layout/MenuBar/MenuBar.module.scss
@@ -44,7 +44,7 @@
       display: none;
     }
 
-    .menuCheckbox:checked ~ ul {
+    .menuCheckbox:checked ~ nav {
       @include mobile {
         visibility: visible;
         opacity: 1;
@@ -118,7 +118,7 @@
       }
     }
 
-    ul {
+    nav {
       margin: 0;
       padding: 0;
       display: flex;
@@ -138,12 +138,6 @@
       @include mobile-fold {
         top: 4rem;
         right: -70%;
-      }
-
-      li {
-        list-style: none;
-        display: flex;
-        align-items: stretch;
       }
     }
 


### PR DESCRIPTION
The purpose of the task was to fix the links to point to the correct category page instead of pointing to `#`.

I have replaced the menu made with unordered list by `NavLink`'s from `react-router-dom` - they inherited all the necessary previous styling of the menu (and `active` class does not stick with the "Home" link, but is now added to the clicked element), so it looks exactly the same, but receives the functionality. I also rechecked if the RWD design still works fine after this changes - actually only two changes were necessary after replacing `ul` by `nav`.

The only thing I am not quite sure about is if the categories except "Home" and "Blog" can be extracted by `map` function from the InitialState - I have tried to copy and adjust the function coming from the `NewFurniture` component but I didn't find the way to make it work.