### PR TITLE
[WDP210101-35] Page content overflow browser window

### DIFF
--- a/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.module.scss
@@ -3,7 +3,7 @@
 
 .root {
   padding: 5rem 0;
-  width: 100vw;
+  width: 100%;
 
   :global(.container) {
     width: 100%;

--- a/src/components/layout/CompanyClaim/CompanyClaim.module.scss
+++ b/src/components/layout/CompanyClaim/CompanyClaim.module.scss
@@ -66,7 +66,7 @@
       position: relative;
       color: $cart-text;
       @include tablet {
-        margin-right: 10px;
+        margin-right: 30px;
       }
 
       .cartIcon {


### PR DESCRIPTION
Bug:

- Page content overflow browser
- On transition between mobile & tablet (568px - 576px) Cart items count overflow browser

What I've done:

- Change FeatureBoxes component width to 100%
- Chagen increse Cart margin on tablet devices